### PR TITLE
Update rtapi.go: switch add,set to set,add

### DIFF
--- a/rtapi.go
+++ b/rtapi.go
@@ -321,8 +321,8 @@ func sendJsonToSplunk(endpoints []endpointDetails, splunkAuthString string) {
 
 		req, err := http.NewRequest("POST", "https://splunk01.ankr.com/hec/services/collector/event", bytes.NewBuffer(jsonStr))
 		log.Print(splunkAuthString)
-		req.Header.Add("Authorization", "Splunk "+splunkAuthString)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Splunk "+splunkAuthString)
 
 		client := &http.Client{}
 		resp, err := client.Do(req)


### PR DESCRIPTION
The Authorization Token was added to the header, and then the header was Set to application/json. Set blows away whatever the header previously was, undoing the work to add the Authorization value. Flipping the lines hopefully fixes it.